### PR TITLE
🎨 Palette: Add Google API Key Help Tooltip

### DIFF
--- a/app.py
+++ b/app.py
@@ -141,7 +141,12 @@ with st.sidebar:
 
     # Standard Env Var
     default_key = os.getenv("GOOGLE_API_KEY", "")
-    api_key = st.text_input("Google API Key", type="password", value=default_key)
+    api_key = st.text_input(
+        "Google API Key",
+        type="password",
+        value=default_key,
+        help="Get your API key at https://aistudio.google.com/app/apikey",
+    )
 
     # "Evergreen" model pointers
     model_choice = st.selectbox(


### PR DESCRIPTION
💡 **What:** Added a help tooltip to the "Google API Key" input field in the sidebar.
🎯 **Why:** Users often struggle to find where to generate their API keys. This tooltip provides a direct link to the Google AI Studio, reducing friction during setup.
♿ **Accessibility:** Uses Streamlit's native tooltip component which is accessible via keyboard and screen readers.


---
*PR created automatically by Jules for task [9611303671578960398](https://jules.google.com/task/9611303671578960398) started by @Fandry96*