### PR TITLE
🎨 Palette: Add help tooltip for API Key input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - API Key Input Help Pattern
+**Learning:** Users often struggle to find where to get API keys. Providing a direct link in a `help` tooltip reduces friction significantly.
+**Action:** For any `st.text_input` requiring an external key, always add `help="... url ..."`.

--- a/app.py
+++ b/app.py
@@ -141,7 +141,12 @@ with st.sidebar:
 
     # Standard Env Var
     default_key = os.getenv("GOOGLE_API_KEY", "")
-    api_key = st.text_input("Google API Key", type="password", value=default_key)
+    api_key = st.text_input(
+        "Google API Key",
+        type="password",
+        value=default_key,
+        help="Required for Gemini models. Get it here: https://aistudio.google.com/app/apikey",
+    )
 
     # "Evergreen" model pointers
     model_choice = st.selectbox(


### PR DESCRIPTION
Added a help tooltip to the Google API Key input field in `app.py` to assist users in obtaining their API key.

---
*PR created automatically by Jules for task [14595307464633091305](https://jules.google.com/task/14595307464633091305) started by @Fandry96*