### PR TITLE
🎨 Palette: Add help tooltip for Google API Key

### DIFF
--- a/app.py
+++ b/app.py
@@ -141,7 +141,12 @@ with st.sidebar:
 
     # Standard Env Var
     default_key = os.getenv("GOOGLE_API_KEY", "")
-    api_key = st.text_input("Google API Key", type="password", value=default_key)
+    api_key = st.text_input(
+        "Google API Key",
+        type="password",
+        value=default_key,
+        help="Get your key at https://aistudio.google.com/app/apikey",
+    )
 
     # "Evergreen" model pointers
     model_choice = st.selectbox(


### PR DESCRIPTION
Added a `help` tooltip to the Google API Key input field in `app.py`. This provides users with a direct link to generate their API key, smoothing the onboarding process. Verified the UI change using Playwright.

---
*PR created automatically by Jules for task [16666117940944832076](https://jules.google.com/task/16666117940944832076) started by @Fandry96*