### PR TITLE
🎨 Palette: Add API Key Tooltip

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - API Key Onboarding
+**Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
+**Action:** Always include a `help` parameter with a direct URL for any external service credential input.

--- a/app.py
+++ b/app.py
@@ -141,7 +141,12 @@ with st.sidebar:
 
     # Standard Env Var
     default_key = os.getenv("GOOGLE_API_KEY", "")
-    api_key = st.text_input("Google API Key", type="password", value=default_key)
+    api_key = st.text_input(
+        "Google API Key",
+        type="password",
+        value=default_key,
+        help="Get your key at https://aistudio.google.com/app/apikey",
+    )
 
     # "Evergreen" model pointers
     model_choice = st.selectbox(


### PR DESCRIPTION
🎨 Palette: Add API Key Tooltip

💡 What: Added a `help` tooltip to the "Google API Key" input field in `app.py` with a direct link to generate a key.
🎯 Why: To reduce friction for new users who may not know where to obtain the required API key, adhering to the "Helpful Additions" UX philosophy.
♿ Accessibility: Provides contextual help without cluttering the interface.


---
*PR created automatically by Jules for task [12408046971774916290](https://jules.google.com/task/12408046971774916290) started by @Fandry96*