### PR TITLE
🎨 Palette: Add help tooltip for Google API Key

### DIFF
--- a/app.py
+++ b/app.py
@@ -141,7 +141,12 @@ with st.sidebar:
 
     # Standard Env Var
     default_key = os.getenv("GOOGLE_API_KEY", "")
-    api_key = st.text_input("Google API Key", type="password", value=default_key)
+    api_key = st.text_input(
+        "Google API Key",
+        type="password",
+        value=default_key,
+        help="Get your key at [Google AI Studio](https://aistudio.google.com/app/apikey)",
+    )
 
     # "Evergreen" model pointers
     model_choice = st.selectbox(


### PR DESCRIPTION
💡 What: Added a help tooltip to the Google API Key input field in `app.py` with a direct link to Google AI Studio.
🎯 Why: Users often struggle to find where to generate API keys. Providing a direct link improves the onboarding experience and reduces friction.
📸 Before/After: Verified with Playwright (screenshots not included in repo).
♿ Accessibility: The tooltip provides context and an actionable link for the input field.

---
*PR created automatically by Jules for task [81961330797463919](https://jules.google.com/task/81961330797463919) started by @Fandry96*