### PR TITLE
🎨 Palette: Enable 'Enter to Submit' for Search

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2025-02-18 - Keyboard Accessibility in Search
+**Learning:** In Streamlit, standard text inputs require a mouse click to submit unless wrapped in a form. This breaks the expected "Type -> Enter" flow for search interfaces.
+**Action:** Always wrap primary search/input-action pairs in `st.form(..., border=False)` to enable "Enter to Submit" without altering the visual design.

--- a/app.py
+++ b/app.py
@@ -167,11 +167,14 @@ with st.sidebar:
     st.metric("Agent Status", "ONLINE" if api_key else "OFFLINE")
 
 st.title("Deep Research Protocol")
-query = st.text_input(
-    "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
-)
 
-if st.button("EXECUTE", type="primary"):
+with st.form(key="mission_form", border=False):
+    query = st.text_input(
+        "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
+    )
+    submit_button = st.form_submit_button("EXECUTE", type="primary")
+
+if submit_button:
     if not api_key:
         st.error("API Key required.")
     else:


### PR DESCRIPTION
💡 What: Wrapped the main search input and execution button in a Streamlit form.
🎯 Why: To allow users to submit the "Mission Objective" by pressing Enter, instead of having to manually click the "EXECUTE" button. This is a standard expected behavior for search interfaces.
📸 Before/After: Visuals are identical (due to `border=False`), but behavior is improved.
♿ Accessibility: Improved keyboard navigation flow (Type -> Enter -> Submit).

---
*PR created automatically by Jules for task [12979035517718246236](https://jules.google.com/task/12979035517718246236) started by @Fandry96*