### PR TITLE
Enable Enter-to-Submit for Search Input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2024-05-24 - Streamlit Form Submission
+**Learning:** Streamlit text inputs do not natively support "Enter to submit" without being wrapped in a form, causing user friction in search-heavy interfaces.
+**Action:** Wrap search/input groups in `st.form(border=False)` and use `st.form_submit_button` to enable keyboard submission while maintaining visual layout.

--- a/app.py
+++ b/app.py
@@ -167,11 +167,13 @@ with st.sidebar:
     st.metric("Agent Status", "ONLINE" if api_key else "OFFLINE")
 
 st.title("Deep Research Protocol")
-query = st.text_input(
-    "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
-)
+with st.form(key="mission_form", border=False):
+    query = st.text_input(
+        "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
+    )
+    submitted = st.form_submit_button("EXECUTE", type="primary")
 
-if st.button("EXECUTE", type="primary"):
+if submitted:
     if not api_key:
         st.error("API Key required.")
     else:


### PR DESCRIPTION
Enabled "Enter to Submit" for the main search input by wrapping the input and button in a Streamlit form. This improves accessibility and usability for keyboard users without altering the visual design.

Verified using a custom Playwright script to ensure:
1. "Enter" key triggers submission.
2. Visual layout remains consistent (no visible form border).

---
*PR created automatically by Jules for task [10577542656961347173](https://jules.google.com/task/10577542656961347173) started by @Fandry96*