### PR TITLE
🎨 Palette: Add 'Enter to Submit' for search

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2026-02-05 - Enter to Submit in Streamlit
+**Learning:** Streamlit users expect "Enter" to trigger form submission, but default `text_input` + `button` requires a click. Using `st.form(border=False)` enables this native behavior without visual clutter.
+**Action:** Wrap search/input groups in borderless forms to enable keyboard submission.

--- a/app.py
+++ b/app.py
@@ -167,11 +167,15 @@ with st.sidebar:
     st.metric("Agent Status", "ONLINE" if api_key else "OFFLINE")
 
 st.title("Deep Research Protocol")
-query = st.text_input(
-    "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
-)
 
-if st.button("EXECUTE", type="primary"):
+# 🎨 Palette: Wrapped in a form to enable 'Enter to Submit'
+with st.form(key="search_form", border=False, clear_on_submit=False):
+    query = st.text_input(
+        "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
+    )
+    submitted = st.form_submit_button("EXECUTE", type="primary")
+
+if submitted:
     if not api_key:
         st.error("API Key required.")
     else:


### PR DESCRIPTION
This PR enhances the UX of the "Deep Research Protocol" search interface by enabling "Enter to Submit" functionality.

### 💡 What
- Wrapped the "Mission Objective" text input and "EXECUTE" button in a Streamlit form.
- Configured the form with `border=False` to maintain the existing visual design.
- Switched to `st.form_submit_button` to handle submission.

### 🎯 Why
- **Usability:** Users instinctively press "Enter" after typing a query. The previous implementation required a separate mouse click on the "EXECUTE" button, creating friction.
- **Accessibility:** Enables keyboard-only submission for the search form.

### ♿ Accessibility
- Standardizes the form submission pattern, providing better support for assistive technologies and keyboard navigation.

### 📸 Verification
- Verified using a Playwright script (`.jules/verification/verify_ux.py`) which confirmed that pressing "Enter" in the input field triggers the submission logic (verified via error message presence).
- Visual inspection confirmed the layout remains unchanged (no extra borders) and the "Press Enter to submit form" hint is present.

---
*PR created automatically by Jules for task [14760902730178217900](https://jules.google.com/task/14760902730178217900) started by @Fandry96*