### PR TITLE
🎨 Palette: Enable Enter-to-Submit for Search

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2024-05-23 - Enter to Submit
+**Learning:** Users expect 'Enter' to submit search queries. Wrapping Streamlit inputs in `st.form(border=False)` enables this behavior without altering visual layout.
+**Action:** Apply this pattern to all primary search/input interfaces.

--- a/app.py
+++ b/app.py
@@ -167,11 +167,13 @@ with st.sidebar:
     st.metric("Agent Status", "ONLINE" if api_key else "OFFLINE")
 
 st.title("Deep Research Protocol")
-query = st.text_input(
-    "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
-)
+with st.form(key="search_form", border=False):
+    query = st.text_input(
+        "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
+    )
+    submitted = st.form_submit_button("EXECUTE", type="primary")
 
-if st.button("EXECUTE", type="primary"):
+if submitted:
     if not api_key:
         st.error("API Key required.")
     else:


### PR DESCRIPTION
Enables "Enter to Submit" functionality for the main search bar by wrapping it in a borderless Streamlit form. This resolves a common UX friction point where users had to manually click "EXECUTE" after typing.

---
*PR created automatically by Jules for task [210947784858164511](https://jules.google.com/task/210947784858164511) started by @Fandry96*