### PR TITLE
feat(ux): enable Enter-to-submit for search

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2025-02-20 - Enter to Submit
+**Learning:** `st.text_input` in Streamlit triggers a rerun on Enter but does not simulate a button click. Wrapping the input and button in `st.form(border=False)` aligns this behavior with user expectations (Enter = Submit) without altering the UI.
+**Action:** Use `st.form` for primary search/action inputs to enable keyboard submission.

--- a/app.py
+++ b/app.py
@@ -167,11 +167,13 @@ with st.sidebar:
     st.metric("Agent Status", "ONLINE" if api_key else "OFFLINE")
 
 st.title("Deep Research Protocol")
-query = st.text_input(
-    "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
-)
+with st.form(key="search_form", border=False):
+    query = st.text_input(
+        "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
+    )
+    submitted = st.form_submit_button("EXECUTE", type="primary")
 
-if st.button("EXECUTE", type="primary"):
+if submitted:
     if not api_key:
         st.error("API Key required.")
     else:


### PR DESCRIPTION
💡 What: Wrapped the main search input and execution button in a Streamlit form.
🎯 Why: Users expect "Enter" in a text input to trigger the search. Previously, it required a manual click on the "EXECUTE" button. This change aligns the behavior with standard search patterns.
♿ Accessibility: Improves keyboard navigation and efficiency.

---
*PR created automatically by Jules for task [16362768206021432186](https://jules.google.com/task/16362768206021432186) started by @Fandry96*