### PR TITLE
UX: enable 'Enter to Submit' for search queries

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2024-05-24 - Streamlit Form Submission
+**Learning:** By default, Streamlit `text_input` widgets do not submit on "Enter". Users expect this behavior in search interfaces. Wrapping inputs and the submit button in `st.form(border=False)` enables this without altering the visual layout.
+**Action:** Always wrap primary search/input groups in a borderless `st.form` to support "Enter" key submission.

--- a/app.py
+++ b/app.py
@@ -167,11 +167,14 @@ with st.sidebar:
     st.metric("Agent Status", "ONLINE" if api_key else "OFFLINE")
 
 st.title("Deep Research Protocol")
-query = st.text_input(
-    "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
-)
 
-if st.button("EXECUTE", type="primary"):
+with st.form(key="search_form", border=False):
+    query = st.text_input(
+        "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
+    )
+    submit_button = st.form_submit_button("EXECUTE", type="primary")
+
+if submit_button:
     if not api_key:
         st.error("API Key required.")
     else:


### PR DESCRIPTION
Wrapped the main search input and execution button in a borderless `st.form`. This allows users to submit the search by pressing the Enter key, improving usability and meeting standard search interface expectations. The visual layout remains unchanged.

---
*PR created automatically by Jules for task [12248202793134337329](https://jules.google.com/task/12248202793134337329) started by @Fandry96*