### PR TITLE
🎨 Palette: Enable 'Enter to Submit' for search

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2024-05-24 - Enter to Submit Pattern
+**Learning:** Streamlit inputs don't submit on Enter by default, causing friction. Wrapping single inputs in `st.form(border=False)` enables this native behavior without visual clutter.
+**Action:** Always wrap primary search/input fields in a borderless form.

--- a/app.py
+++ b/app.py
@@ -167,11 +167,14 @@ with st.sidebar:
     st.metric("Agent Status", "ONLINE" if api_key else "OFFLINE")
 
 st.title("Deep Research Protocol")
-query = st.text_input(
-    "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
-)
 
-if st.button("EXECUTE", type="primary"):
+with st.form(key="search_form", border=False):
+    query = st.text_input(
+        "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
+    )
+    submitted = st.form_submit_button("EXECUTE", type="primary")
+
+if submitted:
     if not api_key:
         st.error("API Key required.")
     else:


### PR DESCRIPTION
💡 What: Wrapped the main search input and execute button in a `st.form` with `border=False`.
🎯 Why: Streamlit inputs do not trigger actions on "Enter" by default. This change allows users to submit queries naturally using the keyboard, improving the search workflow friction.
♿ Accessibility: "Press Enter to submit form" hint is now provided by Streamlit.

---
*PR created automatically by Jules for task [6959743437762899516](https://jules.google.com/task/6959743437762899516) started by @Fandry96*