### PR TITLE
🎨 Palette: Enable Enter-to-Submit for Search

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2024-05-24 - Search Form Submission
+**Learning:** Streamlit's `st.text_input` doesn't support "Enter to submit" by default unless wrapped in a `st.form`. This is a critical pattern for search-heavy interfaces.
+**Action:** Always wrap primary search/input fields in `st.form(border=False)` to enable keyboard submission.

--- a/app.py
+++ b/app.py
@@ -167,11 +167,14 @@ with st.sidebar:
     st.metric("Agent Status", "ONLINE" if api_key else "OFFLINE")
 
 st.title("Deep Research Protocol")
-query = st.text_input(
-    "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
-)
+with st.form(key="mission_form", border=False):
+    query = st.text_input(
+        "Mission Objective",
+        placeholder="e.g., What is the release date of Gemini 3 Pro?",
+    )
+    submitted = st.form_submit_button("EXECUTE", type="primary")
 
-if st.button("EXECUTE", type="primary"):
+if submitted:
     if not api_key:
         st.error("API Key required.")
     else:


### PR DESCRIPTION
🎨 **Palette: Enter-to-Submit for Search**

💡 **What:** Wrapped the "Mission Objective" input and "EXECUTE" button in a `st.form(border=False)`.
🎯 **Why:** Users expect to be able to submit search queries by pressing "Enter". Previously, pressing Enter only refreshed the widget without triggering the search.
📸 **Before/After:** Visually identical (borderless form), but functionally improved.
♿ **Accessibility:** Improves keyboard navigation and usability for all users.

Also fixed a minor journal update format.

---
*PR created automatically by Jules for task [4137787590051939249](https://jules.google.com/task/4137787590051939249) started by @Fandry96*