### PR TITLE
Enable Enter-to-submit for Mission Objective

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2025-02-18 - Enter-to-Submit with Invisible Forms
+**Learning:** Streamlit users expect "Enter" to submit text inputs. `st.form(border=False)` combined with `st.form_submit_button` enables this without altering the visual layout.
+**Action:** Always wrap single-input search/action patterns in a borderless form.

--- a/app.py
+++ b/app.py
@@ -167,11 +167,13 @@ with st.sidebar:
     st.metric("Agent Status", "ONLINE" if api_key else "OFFLINE")
 
 st.title("Deep Research Protocol")
-query = st.text_input(
-    "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
-)
+with st.form(key="mission_form", border=False):
+    query = st.text_input(
+        "Mission Objective", placeholder="e.g., What is the release date of Gemini 3 Pro?"
+    )
+    submitted = st.form_submit_button("EXECUTE", type="primary")
 
-if st.button("EXECUTE", type="primary"):
+if submitted:
     if not api_key:
         st.error("API Key required.")
     else:


### PR DESCRIPTION
Wraps the 'Mission Objective' input and 'EXECUTE' button in a borderless st.form. This allows users to press Enter to submit the form, a standard expectation for search interfaces. The visual layout is preserved.

---
*PR created automatically by Jules for task [16334368743066804400](https://jules.google.com/task/16334368743066804400) started by @Fandry96*