### PR TITLE
UX: Improve API Key Discoverability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2024-10-26 - Persistent Help Links
+**Learning:** Tooltips are great for context, but hidden by default. For critical blockers (like API keys), a persistent `st.caption` with a direct link reduces abandonment more effectively than a tooltip alone.
+**Action:** Use both `help` (for detail) and `st.caption` (for action) on critical setup inputs.

--- a/app.py
+++ b/app.py
@@ -181,8 +181,9 @@ with st.sidebar:
         "Google API Key",
         type="password",
         value=default_key,
-        help="Get your key at https://aistudio.google.com/app/apikey",
+        help="Get your key at [Google AI Studio](https://aistudio.google.com/app/apikey)",
     )
+    st.caption("🔑 [Get your API key here](https://aistudio.google.com/app/apikey)")
 
     # "Evergreen" model pointers
     model_choice = st.selectbox(


### PR DESCRIPTION
Improved the API Key input UX by adding a persistent helper link and updating the tooltip to use a clickable Markdown link. This makes it easier for users to find where to get their API key, reducing onboarding friction. Verified with Playwright tests and screenshots.

---
*PR created automatically by Jules for task [1321537266416998021](https://jules.google.com/task/1321537266416998021) started by @Fandry96*