### PR TITLE
🎨 Palette: Add persistent API key helper link

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2025-02-23 - Persistent Help Links
+**Learning:** Tooltips (via `help` parameter) are often missed by users scanning for setup instructions. For critical blockers like API keys, a persistent text link (e.g., via `st.caption`) significantly reduces abandonment risk compared to hidden tooltips.
+**Action:** Use both: `help` for context, and a persistent `st.caption` link for the primary "Get Key" call-to-action when the field is empty.

--- a/app.py
+++ b/app.py
@@ -183,6 +183,10 @@ with st.sidebar:
         value=default_key,
         help="Get your key at https://aistudio.google.com/app/apikey",
     )
+    if not api_key:
+        st.caption(
+            "[Get your Google API Key here](https://aistudio.google.com/app/apikey)"
+        )
 
     # "Evergreen" model pointers
     model_choice = st.selectbox(


### PR DESCRIPTION
Improved the onboarding UX by adding a persistent "Get your Google API Key here" link below the API Key input in the sidebar. This reduces friction for new users compared to the existing tooltip-only approach. Verified using a Playwright script.

---
*PR created automatically by Jules for task [16041383224598276091](https://jules.google.com/task/16041383224598276091) started by @Fandry96*