### PR TITLE
🎨 Palette: Improve API key onboarding and model selection

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2025-05-27 - Streamlit Input Labels & Formatting
+**Learning:** Technical identifiers (like model IDs) in dropdowns confuse users. Using `format_func` in `st.selectbox` allows presenting friendly names while keeping backend logic clean. Also, persistent captions with links below critical inputs (like API keys) reduce abandonment better than tooltips alone.
+**Action:** Use `format_func` for technical enums and add `st.caption` with direct links below critical setup inputs.

--- a/app.py
+++ b/app.py
@@ -71,6 +71,15 @@ def perform_search(query: str):
         return list(ddgs.text(query, max_results=5))
 
 
+def format_model_name(model_id):
+    """Maps technical model IDs to user-friendly names."""
+    if "flash" in model_id:
+        return "Gemini Flash (Fast)"
+    elif "pro" in model_id:
+        return "Gemini Pro (Smart)"
+    return model_id
+
+
 # --- TOOL DEFINITION ---
 class MarinerSearchTool(Tool):
     name = "web_search"
@@ -183,10 +192,13 @@ with st.sidebar:
         value=default_key,
         help="Get your key at https://aistudio.google.com/app/apikey",
     )
+    st.caption("Don't have a key? [Get one here](https://aistudio.google.com/app/apikey)")
 
     # "Evergreen" model pointers
     model_choice = st.selectbox(
-        "Model Core", ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"]
+        "Model Core",
+        ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"],
+        format_func=format_model_name,
     )
 
     st.divider()


### PR DESCRIPTION
💡 What: Added a persistent caption with a direct link for the API key input and formatted model names in the dropdown.
🎯 Why: Users often struggle to find where to get an API key, and technical model IDs can be confusing.
📸 Before/After: Verified with Playwright screenshots.
♿ Accessibility: Improved discoverability of the API key link and readability of model options.

---
*PR created automatically by Jules for task [2190678985954388775](https://jules.google.com/task/2190678985954388775) started by @Fandry96*