### PR TITLE
🎨 Palette: Improve Model Selection & API Key Onboarding

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2024-05-23 - Mapping Technical IDs to User-Friendly Display Names
+**Learning:** Users can be confused by technical IDs in selectboxes (e.g., "gemini/gemini-flash-latest"). Using the `format_func` parameter in Streamlit's `selectbox` widget maps technical identifiers to user-friendly display names without altering the underlying return values.
+**Action:** Always use a mapping dictionary and `format_func` in `selectbox` for technical IDs to ensure clarity for users while maintaining backend functionality.

--- a/app.py
+++ b/app.py
@@ -181,12 +181,19 @@ with st.sidebar:
         "Google API Key",
         type="password",
         value=default_key,
-        help="Get your key at https://aistudio.google.com/app/apikey",
+        help="[Get your Google API key](https://aistudio.google.com/app/apikey)",
     )
+    st.caption("[Get your Google API key](https://aistudio.google.com/app/apikey)")
 
     # "Evergreen" model pointers
+    MODEL_DISPLAY_NAMES = {
+        "gemini/gemini-flash-latest": "Gemini Flash (Fast)",
+        "gemini/gemini-pro-latest": "Gemini Pro (Smart)"
+    }
     model_choice = st.selectbox(
-        "Model Core", ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"]
+        "Model Core",
+        options=list(MODEL_DISPLAY_NAMES.keys()),
+        format_func=lambda x: MODEL_DISPLAY_NAMES.get(x, x)
     )
 
     st.divider()


### PR DESCRIPTION
* 💡 What: Mapped technical model IDs to user-friendly display names in the selectbox, and added clear, visible links to get a Google API Key beneath the input.
* 🎯 Why: Users can be confused by technical model IDs, so this makes model selection much clearer. Additionally, users often stall at the API key input without a clear path forward, so a persistent link directly under the input smooths out onboarding.
* ♿ Accessibility: Improved label clarity and reduced friction for crucial inputs without modifying backend logic.

---
*PR created automatically by Jules for task [16117389992388854119](https://jules.google.com/task/16117389992388854119) started by @Fandry96*