### PR TITLE
🎨 Palette: Improve model selection UX with friendly names

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2026-03-03 - Technical IDs vs Display Names in Selectboxes
+**Learning:** Exposing technical identifiers (e.g., 'gemini/gemini-flash-latest') in UI select menus can confuse users and look unpolished. Streamlit's `format_func` parameter enables mapping these IDs to user-friendly labels (like 'Gemini Flash (Fast)') while retaining the underlying technical value for backend operations.
+**Action:** Use `format_func` in `st.selectbox` (or similar selection widgets) whenever presenting technical model IDs, system strings, or raw identifiers to end users.

--- a/app.py
+++ b/app.py
@@ -186,7 +186,9 @@ with st.sidebar:
 
     # "Evergreen" model pointers
     model_choice = st.selectbox(
-        "Model Core", ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"]
+        "Model Core",
+        ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"],
+        format_func=lambda x: "Gemini Flash (Fast)" if x == "gemini/gemini-flash-latest" else "Gemini Pro (Smart)" if x == "gemini/gemini-pro-latest" else x
     )
 
     st.divider()


### PR DESCRIPTION
**💡 What:** We updated the `st.selectbox` for the "Model Core" selection to use Streamlit's `format_func` parameter, mapping the raw technical IDs to human-readable strings.
**🎯 Why:** Exposing technical strings (like `gemini/gemini-flash-latest`) to end-users is confusing and looks unpolished. By using `format_func`, users see descriptive labels ("Gemini Flash (Fast)") while the system still works with the correct technical IDs under the hood.
**📸 Before/After:** Before, the dropdown displayed "gemini/gemini-flash-latest". Now it displays "Gemini Flash (Fast)".
**♿ Accessibility:** Improves cognitive accessibility by clearly describing what the model does ("Fast" vs "Smart") instead of relying on the user to understand internal naming conventions.

---
*PR created automatically by Jules for task [1592330630672221341](https://jules.google.com/task/1592330630672221341) started by @Fandry96*