### PR TITLE
🎨 Palette: Improve setup UX and model selection readability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2026-03-04 - Enhanced API Key Onboarding
+**Learning:** Relying solely on tooltips for critical setup inputs like API keys can lead to abandonment since the tooltip must be hovered over to be seen. A persistent caption alongside the tooltip increases visibility and click-through.
+**Action:** Use both a `help` tooltip with a Markdown link and a persistent `st.caption` with a direct link for critical setup inputs.

--- a/app.py
+++ b/app.py
@@ -181,12 +181,19 @@ with st.sidebar:
         "Google API Key",
         type="password",
         value=default_key,
-        help="Get your key at https://aistudio.google.com/app/apikey",
+        help="Get your key at [Google AI Studio](https://aistudio.google.com/app/apikey)",
     )
+    st.caption("🔑 [Get your Google API Key here](https://aistudio.google.com/app/apikey)")
 
     # "Evergreen" model pointers
+    MODEL_DISPLAY_NAMES = {
+        "gemini/gemini-flash-latest": "Gemini Flash (Fast)",
+        "gemini/gemini-pro-latest": "Gemini Pro (Smart)",
+    }
     model_choice = st.selectbox(
-        "Model Core", ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"]
+        "Model Core",
+        options=list(MODEL_DISPLAY_NAMES.keys()),
+        format_func=lambda x: MODEL_DISPLAY_NAMES.get(x, x),
     )
 
     st.divider()


### PR DESCRIPTION
Implemented two micro-UX enhancements as the Palette persona:
1.  **API Key Onboarding:** Replaced the hidden tooltip-only approach with a persistent caption link for the API Key acquisition URL. This reduces friction during initial setup.
2.  **Model Selection:** Mapped raw model IDs to friendly display names using Streamlit's `format_func`.

Changes kept strictly under 50 lines and verified with a Playwright script. Added a critical UX learning to `.jules/palette.md`.

---
*PR created automatically by Jules for task [15451760281088386239](https://jules.google.com/task/15451760281088386239) started by @Fandry96*