### PR TITLE
🎨 Palette: Improve model selection and API key onboarding UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+## 2024-05-23 - Model Selectbox Display Names\n**Learning:** Streamlit selectboxes can display user-friendly names while returning technical IDs using `format_func`.\n**Action:** Use `format_func` in `st.selectbox` for mapping model IDs to readable names.

--- a/app.py
+++ b/app.py
@@ -181,12 +181,19 @@ with st.sidebar:
         "Google API Key",
         type="password",
         value=default_key,
-        help="Get your key at https://aistudio.google.com/app/apikey",
+        help="[Get your key](https://aistudio.google.com/app/apikey)",
     )
+    st.caption("[Get an API Key here](https://aistudio.google.com/app/apikey)")
 
     # "Evergreen" model pointers
+    model_mapping = {
+        "gemini/gemini-flash-latest": "Gemini Flash (Fast)",
+        "gemini/gemini-pro-latest": "Gemini Pro (Smart)",
+    }
     model_choice = st.selectbox(
-        "Model Core", ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"]
+        "Model Core",
+        options=list(model_mapping.keys()),
+        format_func=lambda x: model_mapping.get(x, x)
     )
 
     st.divider()


### PR DESCRIPTION
### 💡 What:
- Updated the "Model Core" selectbox to display user-friendly names (e.g., "Gemini Flash (Fast)") instead of technical IDs (e.g., "gemini/gemini-flash-latest").
- Updated the API key input to feature a clickable markdown link in its tooltip, and added a persistent caption below it that links directly to the Google AI Studio to fetch a key.

### 🎯 Why:
- **Model Selection:** Exposing technical IDs is visually noisy and confusing to non-technical users. Friendly names make it clear what the tradeoff is between the two models (Fast vs. Smart).
- **API Key Onboarding:** Users often abandon apps when confronted with an API key requirement they don't know how to fulfill. The tooltip helps, but a permanent link is more discoverable.

### ♿ Accessibility:
- The persistent link ensures users don't have to hover/focus to find the instructions on how to use the app. It's plainly visible.

### 📸 Before/After:
*Before:*
- Model Selectbox: `gemini/gemini-flash-latest`
- API Key Input: "Get your key at https://..." (unclickable text)

*After:*
- Model Selectbox: `Gemini Flash (Fast)`
- API Key Input: Link icon in tooltip is clickable, and a permanent `[Get an API Key here]` link lives directly below the input.

---
*PR created automatically by Jules for task [12748296445414159178](https://jules.google.com/task/12748296445414159178) started by @Fandry96*