### PR TITLE
🎨 Palette: Add explicit API key link and descriptive model names

### DIFF
--- a/app.py
+++ b/app.py
@@ -183,10 +183,13 @@ with st.sidebar:
         value=default_key,
         help="Get your key at https://aistudio.google.com/app/apikey",
     )
+    st.caption("[Get Google API Key here](https://aistudio.google.com/app/apikey)")
 
     # "Evergreen" model pointers
     model_choice = st.selectbox(
-        "Model Core", ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"]
+        "Model Core",
+        ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"],
+        format_func=lambda x: "Gemini Flash (Fast)" if "flash" in x else "Gemini Pro (Smart)"
     )
 
     st.divider()


### PR DESCRIPTION
💡 **What**:
- Added a persistent, clickable link using `st.caption` right below the Google API Key input field.
- Updated the "Model Core" selectbox to display friendly, descriptive names ("Gemini Flash (Fast)", "Gemini Pro (Smart)") instead of raw model IDs ("gemini/gemini-flash-latest", "gemini/gemini-pro-latest").

🎯 **Why**:
- **API Key Link**: As noted in previous UX reviews, users often stall during setup when they don't know where to acquire an API key. Relying solely on a `help` tooltip is low-intrusiveness but easily missed. A persistent, clickable link explicitly below the input significantly reduces onboarding friction and abandonment.
- **Model Names**: Displaying raw technical model IDs isn't intuitive for all users. Adding descriptive labels like "(Fast)" and "(Smart)" helps users make an informed choice quickly, without altering the underlying technical string required by the backend logic.

📸 **Before/After**:
- *Before*: API key link was hidden in a small `?` tooltip. Dropdown showed `gemini/gemini-flash-latest`.
- *After*: API link `[Get Google API Key here]` is immediately visible under the input. Dropdown shows `Gemini Flash (Fast)`.

♿ **Accessibility**:
- The clickable API key link is more discoverable and accessible than a hover-based tooltip (especially on touch devices).
- Descriptive model names improve cognitive accessibility by clarifying the purpose and trade-offs of the options.

---
*PR created automatically by Jules for task [7184675537497666141](https://jules.google.com/task/7184675537497666141) started by @Fandry96*