### PR TITLE
🎨 Palette: Map model IDs to user-friendly names and improve API key onboarding

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2024-05-24 - Technical Jargon in UI & Persistent Onboarding
+**Learning:** Exposing technical model IDs (e.g., `gemini/gemini-flash-latest`) is confusing to non-technical users. Additionally, users often miss tooltips (like the `help` icon), making critical onboarding links (like API keys) hard to find, leading to abandonment.
+**Action:** Use `format_func` in Streamlit selectboxes to map technical IDs to user-friendly names without changing the underlying value. Use persistent UI elements (like `st.caption` with Markdown links) near critical empty inputs to ensure visibility, rather than relying solely on tooltips.

--- a/app.py
+++ b/app.py
@@ -181,12 +181,20 @@ with st.sidebar:
         "Google API Key",
         type="password",
         value=default_key,
-        help="Get your key at https://aistudio.google.com/app/apikey",
+        help="Get your key at [Google AI Studio](https://aistudio.google.com/app/apikey)",
     )
+    if not api_key:
+        st.caption("🔑 [Get a free API key](https://aistudio.google.com/app/apikey)")
 
     # "Evergreen" model pointers
+    MODEL_DISPLAY_NAMES = {
+        "gemini/gemini-flash-latest": "Gemini Flash (Fast)",
+        "gemini/gemini-pro-latest": "Gemini Pro (Smart)"
+    }
     model_choice = st.selectbox(
-        "Model Core", ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"]
+        "Model Core",
+        options=["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"],
+        format_func=lambda x: MODEL_DISPLAY_NAMES.get(x, x)
     )
 
     st.divider()


### PR DESCRIPTION
💡 **What:** 
- Mapped technical model IDs (like `gemini/gemini-flash-latest`) to intuitive display names (`Gemini Flash (Fast)`) in the select box using `format_func`.
- Enhanced the API key input by turning the plain text help URL into a clickable Markdown link and adding a persistent, clickable `st.caption` below the input when empty.
- Documented these learnings in `.jules/palette.md`.

🎯 **Why:** 
- **Technical Jargon:** Exposing raw model IDs can be confusing for non-technical users. Abstracting them to user-friendly names makes the UI much more intuitive without changing the underlying backend logic.
- **Onboarding Abandonment:** Users often miss the tiny `?` help tooltip, which makes critical onboarding links (like getting an API key) hard to discover. A persistent, clickable link directly below the input drastically improves the onboarding flow.

📸 **Before/After:**
*(See Playwright verification screenshot for visual confirmation of the new dropdown names and the new caption link)*

♿ **Accessibility:**
- Improves cognitive accessibility by replacing technical jargon with descriptive, plain-language labels.
- Improves general accessibility by providing a visible, persistent link to required resources rather than hiding them behind a hover-only tooltip.

---
*PR created automatically by Jules for task [17980344938914932661](https://jules.google.com/task/17980344938914932661) started by @Fandry96*