### PR TITLE
🎨 Palette: Streamlit UX Enhancements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2025-03-09 - Persistent Setup Links & Friendly Names
+**Learning:** The `help` tooltip alone can sometimes be missed or ignored during critical onboarding (like entering an API key). Using a persistent `st.caption` with a direct Markdown link ensures the fallback URL is always visible. Additionally, displaying raw technical identifiers (like 'gemini/gemini-flash-latest') in drop-downs causes cognitive load, while mapping them to user-friendly names improves clarity.
+**Action:** For critical setup inputs, use both a `help` tooltip and a persistent `st.caption` with a direct link. Use the `format_func` parameter in `st.selectbox` to map technical identifiers to user-friendly display names without altering the underlying return values.

--- a/app.py
+++ b/app.py
@@ -183,10 +183,17 @@ with st.sidebar:
         value=default_key,
         help="Get your key at https://aistudio.google.com/app/apikey",
     )
+    st.caption("Get your key at [Google AI Studio](https://aistudio.google.com/app/apikey)")
 
     # "Evergreen" model pointers
+    model_names = {
+        "gemini/gemini-flash-latest": "Gemini Flash (Fast)",
+        "gemini/gemini-pro-latest": "Gemini Pro (Smart)"
+    }
     model_choice = st.selectbox(
-        "Model Core", ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"]
+        "Model Core",
+        ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"],
+        format_func=lambda x: model_names.get(x, x)
     )
 
     st.divider()


### PR DESCRIPTION
### 💡 What:
- Added a persistent `st.caption` containing a Markdown link to Google AI Studio directly beneath the API key input.
- Added a `format_func` parameter to the `st.selectbox` for the "Model Core", mapping technical model IDs (`gemini/gemini-flash-latest`, etc.) to user-friendly names (`Gemini Flash (Fast)`, `Gemini Pro (Smart)`).
- Added an entry in `.jules/palette.md` detailing this learning.

### 🎯 Why:
- **API Key Abandonment:** While the `help` tooltip provides the link, it requires hover interaction and can be missed. A persistent caption ensures the link is always visible during the critical setup phase.
- **Cognitive Load:** Displaying raw backend identifiers (like `gemini/gemini-flash-latest`) forces the user to parse technical strings. Mapping these to simple, friendly names (e.g., `Gemini Flash (Fast)`) makes the interface significantly more intuitive without altering the backend logic.

### 📸 Before/After:
**Before:**
- API link only visible on hover (`?` icon).
- Model dropdown showed technical IDs: `gemini/gemini-flash-latest` and `gemini/gemini-pro-latest`.

**After:**
- "Get your key at Google AI Studio" permanently visible below the input.
- Model dropdown shows user-friendly names: "Gemini Flash (Fast)" and "Gemini Pro (Smart)".

### ♿ Accessibility:
- Reduced cognitive load by replacing technical identifiers with plain English.
- Eliminated the requirement for hover interaction to discover the API key link, improving the experience for users on touch devices or those using keyboard navigation.

---
*PR created automatically by Jules for task [10198674965793972912](https://jules.google.com/task/10198674965793972912) started by @Fandry96*