### PR TITLE
🎨 Palette: Add friendly model names and visible API key link

### DIFF
--- a/app.py
+++ b/app.py
@@ -181,12 +181,19 @@ with st.sidebar:
         "Google API Key",
         type="password",
         value=default_key,
-        help="Get your key at https://aistudio.google.com/app/apikey",
+        help="Get your key at [Google AI Studio](https://aistudio.google.com/app/apikey)",
     )
+    st.caption("[Get an API Key](https://aistudio.google.com/app/apikey)")
 
     # "Evergreen" model pointers
+    MODEL_DISPLAY_NAMES = {
+        "gemini/gemini-flash-latest": "Gemini Flash (Fast)",
+        "gemini/gemini-pro-latest": "Gemini Pro (Smart)"
+    }
     model_choice = st.selectbox(
-        "Model Core", ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"]
+        "Model Core",
+        options=list(MODEL_DISPLAY_NAMES.keys()),
+        format_func=lambda x: MODEL_DISPLAY_NAMES.get(x, x)
     )
 
     st.divider()


### PR DESCRIPTION
### 💡 What:
1. Replaced raw technical model IDs (`gemini/gemini-flash-latest`) in the selectbox with user-friendly display names (`Gemini Flash (Fast)`) using Streamlit's `format_func`.
2. Converted the API key input's `help` tooltip to use a clickable Markdown link.
3. Added a persistent, always-visible caption with a direct link to Google AI Studio below the API key input.

### 🎯 Why:
- **Model Names:** Users shouldn't have to parse technical backend IDs to understand their choices. "Fast" and "Smart" descriptors help users make immediate, informed decisions.
- **API Key Link:** Analytics/Journals show users often stall when they don't know where to get an API key. While tooltips are helpful, a persistent link ensures the onboarding path is never hidden.

### ♿ Accessibility:
- The persistent link provides a clear, visible focus target for keyboard users and is easily read by screen readers without requiring a hover/focus interaction to discover the tooltip.

### 📸 Before/After:
**Before:**
- Selectbox options: `gemini/gemini-flash-latest`, `gemini/gemini-pro-latest`
- API Key help text: unclickable plain text `https://aistudio...` hidden in a tooltip.

**After:**
- Selectbox options: `Gemini Flash (Fast)`, `Gemini Pro (Smart)`
- API Key help text: clickable Markdown link in tooltip AND a persistent caption `[Get an API Key]` always visible below the input.

---
*PR created automatically by Jules for task [634585246344436272](https://jules.google.com/task/634585246344436272) started by @Fandry96*