### PR TITLE
🎨 Palette: [Improve API Key Onboarding and Model Name Clarity]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2024-05-24 - Model Name Display
+**Learning:** Exposing raw model IDs in UI dropdowns confuses non-technical users. Streamlit's `format_func` allows displaying user-friendly names while retaining technical IDs as the underlying value.
+**Action:** Use `format_func` in `st.selectbox` for model selection to map technical IDs to descriptive names.

--- a/app.py
+++ b/app.py
@@ -181,12 +181,19 @@ with st.sidebar:
         "Google API Key",
         type="password",
         value=default_key,
-        help="Get your key at https://aistudio.google.com/app/apikey",
+        help="Get your key at [Google AI Studio](https://aistudio.google.com/app/apikey)",
     )
+    st.caption("Don't have an API key? [Get one here](https://aistudio.google.com/app/apikey)")
 
     # "Evergreen" model pointers
+    model_names = {
+        "gemini/gemini-flash-latest": "Gemini Flash (Fast)",
+        "gemini/gemini-pro-latest": "Gemini Pro (Smart)"
+    }
     model_choice = st.selectbox(
-        "Model Core", ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"]
+        "Model Core",
+        ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"],
+        format_func=lambda x: model_names.get(x, x)
     )
 
     st.divider()


### PR DESCRIPTION
### 💡 What:
- Updated the API key text input to include a clickable Markdown link in its `help` tooltip.
- Added a persistent `st.caption` below the API key input with a direct link to Google AI Studio.
- Implemented `format_func` in the "Model Core" `st.selectbox` to map raw technical model IDs (`gemini/gemini-flash-latest`, `gemini/gemini-pro-latest`) to user-friendly names (`Gemini Flash (Fast)`, `Gemini Pro (Smart)`).
- Logged this learning in `.jules/palette.md`.

### 🎯 Why:
Users often stall or abandon workflows if they don't know where to obtain necessary credentials (like an API Key). Providing direct, persistent links reduces friction. Furthermore, exposing raw model IDs confuses non-technical users. Using descriptive names improves clarity and confidence in model selection.

### 📸 Before/After:
**Before:**
- API Key `help` text was a raw, unclickable URL.
- Model Core dropdown displayed technical strings: `gemini/gemini-flash-latest` and `gemini/gemini-pro-latest`.

**After:**
- API Key `help` text contains a clean `[Google AI Studio]` link.
- A persistent caption "Don't have an API key? [Get one here]" is visible below the input.
- Model Core dropdown displays clear labels: `Gemini Flash (Fast)` and `Gemini Pro (Smart)`.

### ♿ Accessibility:
- Improves cognitive accessibility by replacing technical jargon with plain language (Fast/Smart) in the model dropdown.
- Reduces cognitive load by providing clear, immediate context and actionable links for obtaining required credentials.

---
*PR created automatically by Jules for task [2359187423639322269](https://jules.google.com/task/2359187423639322269) started by @Fandry96*