### PR TITLE
🎨 Palette: Improve API key onboarding and model selection UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,11 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2024-05-23 - API Key Onboarding
+**Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link, and a persistent caption ensures visibility even before interaction.
+**Action:** Always include a `help` parameter with a Markdown URL for any external service credential input. Include a persistent `st.caption` below the input if the value is missing.
+
+## 2024-05-23 - Selectbox Model Names
+**Learning:** Displaying technical IDs (like "gemini/gemini-flash-latest") in selectboxes degrades UX by exposing implementation details. The `format_func` parameter in `st.selectbox` efficiently maps these internal values to user-friendly labels without breaking backend expectations.
+**Action:** Use `format_func` to display user-friendly names for model selection or similar technical identifiers.

--- a/app.py
+++ b/app.py
@@ -181,12 +181,16 @@ with st.sidebar:
         "Google API Key",
         type="password",
         value=default_key,
-        help="Get your key at https://aistudio.google.com/app/apikey",
+        help="Get your key at [Google AI Studio](https://aistudio.google.com/app/apikey)",
     )
+    if not api_key:
+        st.caption("Need a key? Get one [here](https://aistudio.google.com/app/apikey)")
 
     # "Evergreen" model pointers
     model_choice = st.selectbox(
-        "Model Core", ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"]
+        "Model Core",
+        ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"],
+        format_func=lambda x: "Gemini Flash (Fast)" if "flash" in x else "Gemini Pro (Smart)"
     )
 
     st.divider()


### PR DESCRIPTION
### 💡 What:
- Updated the API key input tooltip to contain a clickable Markdown link.
- Added a persistent helper text (caption) below the API Key input that displays when no key is entered.
- Updated the `model_choice` `selectbox` to use `format_func` to display user-friendly model names ("Gemini Flash (Fast)", "Gemini Pro (Smart)") instead of technical IDs.
- Appended two critical UX learnings to the `.jules/palette.md` journal.

### 🎯 Why:
- **API Key Onboarding:** Users often abandon setup flows if they don't immediately know where to acquire an API key. A persistent link and an informative tooltip reduce this friction.
- **Model Selection UX:** Exposing internal technical strings (like "gemini/gemini-flash-latest") in dropdown menus degrades user experience and trust. By mapping these to human-readable names, we make the interface more intuitive without altering backend dependencies or logic.

### 📸 Before/After:
**Before:**
- API Key input tooltip had plain text "Get your key at https://aistudio.google.com/app/apikey"
- Model dropdown displayed "gemini/gemini-flash-latest" and "gemini/gemini-pro-latest"

**After:**
- API Key input tooltip has a formatted Markdown link.
- "Need a key? Get one [here]" displays persistently below the empty API Key input.
- Model dropdown displays "Gemini Flash (Fast)" and "Gemini Pro (Smart)".

### ♿ Accessibility:
- The persistent caption ensures that crucial onboarding information is always visible, unlike a hover-only tooltip, which can be difficult to trigger via keyboard navigation or on mobile devices.

---
*PR created automatically by Jules for task [13204799020322936574](https://jules.google.com/task/13204799020322936574) started by @Fandry96*