### PR TITLE
⚡ Bolt: Remove redundant StringIO buffer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-02-23 - Streamlit ANSI Cleaning Optimization
 **Learning:** Cleaning ANSI codes from accumulating logs in `capture_stdout` using `clean_ansi(full_buffer)` is an O(N^2) operation. For long-running agents with verbose output, this causes significant lag.
 **Action:** Implement incremental cleaning: clean new chunks *before* appending to the buffer, making the operation O(N).
+
+## 2025-03-12 - Redundant Write-Only StringIO Buffer Overhead
+**Learning:** In highly iterative tight loops (like Streamlit text streaming or real-time chunk cleaning), writing to write-only objects (e.g., a redundant `new_out = StringIO()` meant for a future read but never used) incurs unnecessary memory allocation and string write operations, drastically impacting loop overhead.
+**Action:** Always scan for and remove unread or write-only `StringIO` buffers in tight rendering or parsing loops to avoid the memory overhead and CPU cycles spent appending strings to them.

--- a/app.py
+++ b/app.py
@@ -130,7 +130,6 @@ def clean_ansi(text):
 @contextmanager
 def capture_stdout(placeholder):
     """Redirects stdout to a Streamlit placeholder in real-time with throttling."""
-    new_out = StringIO()
     cleaned_buffer = StringIO()  # Incremental cleaned output buffer
     old_out = sys.stdout
 
@@ -149,7 +148,6 @@ def capture_stdout(placeholder):
 
     class RealTimeStream:
         def write(self, s):
-            new_out.write(s)
             # Incrementally clean new chunk and append to cleaned_buffer
             # This avoids re-scanning the entire history for ANSI codes on every update
             cleaned_s = clean_ansi(s)


### PR DESCRIPTION
💡 **What:** Removed an unused, write-only `StringIO` object (`new_out`) and its associated `.write()` call from the `RealTimeStream` inner class within the `capture_stdout` context manager in `app.py`.

🎯 **Why:** In real-time logging or streaming loops, writing to an unused buffer incurs unnecessary memory allocation and string-processing overhead. `new_out` was an artifact that was never read or utilized, wasting CPU cycles and memory on every stdout flush.

📊 **Impact:** Reduces memory allocation overhead and eliminates a redundant operation in a tight stream-processing loop. Removing this $O(1)$ constant-time write from an iterative loop improves the loop's theoretical baseline performance.

🔬 **Measurement:** Code was verified manually. You can profile the execution of the `capture_stdout` block with verbose agent logs to measure reduced memory peak. Additionally, visual validation verified that Streamlit correctly captures and renders logs without this redundant variable.

---
*PR created automatically by Jules for task [17507122095422229649](https://jules.google.com/task/17507122095422229649) started by @Fandry96*