### PR TITLE
🎨 Palette: [UX improvement] Use friendly display names for model selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -185,8 +185,14 @@ with st.sidebar:
     )
 
     # "Evergreen" model pointers
+    model_names = {
+        "gemini/gemini-flash-latest": "Gemini Flash (Fast)",
+        "gemini/gemini-pro-latest": "Gemini Pro (Smart)"
+    }
     model_choice = st.selectbox(
-        "Model Core", ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"]
+        "Model Core",
+        ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"],
+        format_func=lambda x: model_names.get(x, x)
     )
 
     st.divider()


### PR DESCRIPTION
💡 What: Replaced technical model IDs ("gemini/gemini-flash-latest") with user-friendly display names ("Gemini Flash (Fast)", "Gemini Pro (Smart)") in the Streamlit selectbox.
🎯 Why: To make the interface more intuitive for users without deep technical knowledge, allowing them to choose the correct model based on capability (Fast vs Smart) rather than memorizing internal IDs.
📸 Before/After: Before, the dropdown displayed `gemini/gemini-flash-latest`. After, it displays `Gemini Flash (Fast)`.
♿ Accessibility: Reduces cognitive load and confusion by using plain English labels, a key component of accessible and inclusive design.

---
*PR created automatically by Jules for task [3365968144528251582](https://jules.google.com/task/3365968144528251582) started by @Fandry96*