### PR TITLE
🎨 Palette: Improve sidebar accessibility and readability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - API Key Onboarding
 **Learning:** Users often stall at the "API Key" input if they don't know where to get one. Streamlit's `help` tooltip is a low-intrusiveness way to provide this link.
 **Action:** Always include a `help` parameter with a direct URL for any external service credential input.
+
+## 2024-05-28 - Model Names Readability & Persistent Links
+**Learning:** Raw technical IDs for models (like `gemini/gemini-flash-latest`) are confusing for non-technical users. Additionally, relying solely on tooltips for credential links leads to abandonment because users might not hover over the input.
+**Action:** Use `format_func` in `st.selectbox` to map technical IDs to user-friendly display names without altering the underlying return values. For critical setup inputs (e.g., API keys), use both a `help` tooltip with a Markdown link and a persistent `st.caption` with a direct link to reduce abandonment.

--- a/app.py
+++ b/app.py
@@ -183,10 +183,17 @@ with st.sidebar:
         value=default_key,
         help="Get your key at https://aistudio.google.com/app/apikey",
     )
+    st.caption("[Get your key at Google AI Studio](https://aistudio.google.com/app/apikey)")
 
     # "Evergreen" model pointers
+    model_mapping = {
+        "gemini/gemini-flash-latest": "Gemini Flash (Fast)",
+        "gemini/gemini-pro-latest": "Gemini Pro (Smart)"
+    }
     model_choice = st.selectbox(
-        "Model Core", ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"]
+        "Model Core",
+        ["gemini/gemini-flash-latest", "gemini/gemini-pro-latest"],
+        format_func=lambda x: model_mapping.get(x, x)
     )
 
     st.divider()


### PR DESCRIPTION
💡 **What:** 
1. Added a persistent `st.caption` with a direct link to Google AI Studio right below the API key input.
2. Implemented `format_func` on the model `st.selectbox` to display human-readable names ("Gemini Flash (Fast)" and "Gemini Pro (Smart)") instead of the raw technical identifiers ("gemini/gemini-flash-latest").
3. Recorded these learnings in `.jules/palette.md`.

🎯 **Why:** 
1. Users often stall or abandon setup if they don't know where to get an API key. Relying solely on a hover tooltip hides this critical information. A persistent link directly under the input provides an immediate, clear path to success.
2. Raw technical model IDs are confusing for non-technical users and look unpolished in the UI. Using readable names improves clarity and reduces cognitive load, while preserving the exact technical IDs needed for the backend logic.

📸 **Before/After:**
*Before:* API Key had a hidden tooltip link. Model selectbox showed raw IDs like `gemini/gemini-flash-latest`.
*After:* API Key has a clear "Get your key at Google AI Studio" link. Model selectbox shows "Gemini Flash (Fast)".

♿ **Accessibility:**
- The persistent link improves cognitive accessibility by providing immediate, visible instructions for credential acquisition without requiring fine motor control to trigger a tooltip.
- Human-readable model names are significantly easier to read and comprehend, especially for screen readers which might mispronounce or laboriously spell out complex string identifiers with slashes.

---
*PR created automatically by Jules for task [8312264481218524410](https://jules.google.com/task/8312264481218524410) started by @Fandry96*